### PR TITLE
fix(build): add msvc build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ build-*/
 
 .idea/
 cmake-build-debug/
+cmake-build-release/
 .venv/
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(Dictorium)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_VERBOSE_MAKEFILE ON)
 
 set(DICTORIUM_SOURCES
        src/dtr.cpp
@@ -26,5 +27,4 @@ add_executable(PerfHashSpeed
         tests/PerfTest.cpp
         tests/Utils/TestUtils.cpp
 )
-target_compile_options(PerfHashSpeed PRIVATE -O2)
 target_link_libraries(PerfHashSpeed Dictorium)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,12 @@ add_library(Dictorium STATIC
 target_include_directories(Dictorium PUBLIC include)
 target_include_directories(Dictorium PUBLIC src)
 
-add_executable(DictoriumRun
+add_executable(DictoriumMain
         tests/main.cpp
         tests/Utils/PrintUtils.cpp
 )
 
-target_link_libraries(DictoriumRun Dictorium)
+target_link_libraries(DictoriumMain Dictorium)
 
 add_executable(PerfHashSpeed
         tests/PerfTest.cpp

--- a/include/Dictorium/Entities/Console.h
+++ b/include/Dictorium/Entities/Console.h
@@ -33,34 +33,6 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& vector) 
 template<typename T>
 concept CPrintable = requires(std::ostream& os, T value){ os << value; };
 
-
-template<CPrintable T>
-inline void print(T&& last) {
-    std::cout << last << '\n';
-}
-
-template <CPrintable T, CPrintable... Args>
-inline void print(T&& first, Args&&... args) {
-    std::cout<<first<<' ';
-    print(std::forward<Args>(args)...);
-}
-
-
-
-inline std::string input() {
-    std::string input;
-    std::getline(std::cin, input);
-    return input;
-}
-
-template <CPrintable T, CPrintable... Args>
-inline std::string input(T&& first, Args&&... args) {
-    std::cout<<first<<' ';
-
-    if constexpr (sizeof...(args) > 0) print(std::forward<Args>(args)...);
-    return input();
-}
-
 }
 
 #endif //CONSOLE_H

--- a/include/Dictorium/Entities/LinearDictionary.h
+++ b/include/Dictorium/Entities/LinearDictionary.h
@@ -127,10 +127,11 @@ private:
     std::vector<std::pair<TKey, TValue>> _dict;
 };
 
+
+}
+
 #include "LinearDictionary/LinearDictionary.tpp"
 #include "LinearDictionary/LinearDictionarySetters.tpp"
 #include "LinearDictionary/LinearDictionaryGetters.tpp"
-
-}
 
 #endif //LINEARDICTIONARY_H

--- a/include/Dictorium/Entities/PerfectHashDictionary.h
+++ b/include/Dictorium/Entities/PerfectHashDictionary.h
@@ -14,6 +14,13 @@
 #define PERFECTHASH_DICT_NAME "PerfectHashDictionary"
 #define PERFECTHASH_DEPRECATED_KEYS "Valid only for keys from the original set"
 
+#ifdef _MSC_VER
+    #include <xmmintrin.h>
+    #define PH_PREFETCH(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+    #else
+    #define PH_PREFETCH(addr) __builtin_prefetch(addr, 0, 1)
+#endif
+
 namespace dtr{
 
 struct PhBucket {
@@ -189,8 +196,14 @@ public:
 
 private:
 
-    static inline size_t _fastRange(const uint64_t hash, const size_t count) {
-        return ((__uint128_t)hash * count) >> 64;
+    static inline uint64_t _fastRange(uint64_t a, uint64_t b) {
+    #ifdef _MSC_VER
+            uint64_t high;
+            _umul128(a, b, &high);
+            return high;
+    #else
+            return static_cast<uint64_t>((static_cast<__uint128_t>(a) * b) >> 64);
+    #endif
     }
 
     static inline size_t _hashRaw(const uint64_t stdHash, const uint64_t seed, const size_t tableSize) {
@@ -227,9 +240,10 @@ private:
     }
 };
 
+}
+
 #include "PerfectHashDictionary/PerfectHashDictionaryBuild.tpp"
 #include "PerfectHashDictionary/PerfectHashDictionaryGetters.tpp"
 #include "PerfectHashDictionary/PerfectHashDictionarySetters.tpp"
 
-}
 #endif //PERFECTHASHDICTIONARY_H

--- a/src/LinearDictionary/LinearDictionary.tpp
+++ b/src/LinearDictionary/LinearDictionary.tpp
@@ -1,6 +1,8 @@
 #ifndef LINEARDICTIONARY_TPP
 #define LINEARDICTIONARY_TPP
 
+namespace dtr
+{
 
 template <typename TKey, typename TValue>
 bool LinearDictionary<TKey, TValue>::ContainsKey(const TKey& key) const {
@@ -32,6 +34,5 @@ size_t LinearDictionary<TKey, TValue>::Count() const {
     return _dict.size();
 }
 
-
-
+}
 #endif // LINEARDICTIONARY_TPP

--- a/src/LinearDictionary/LinearDictionaryGetters.tpp
+++ b/src/LinearDictionary/LinearDictionaryGetters.tpp
@@ -1,6 +1,9 @@
 #ifndef LINEARDICTIONARYGETTERS_TPP
 #define LINEARDICTIONARYGETTERS_TPP
 
+namespace dtr
+{
+
 template <typename TKey, typename TValue>
 TValue& LinearDictionary<TKey, TValue>::GetValue(const TKey& key) {
     for (auto& p : _dict) {
@@ -28,4 +31,5 @@ bool LinearDictionary<TKey, TValue>::TryGetValue(const TKey& key, TValue& value)
     return false;
 }
 
+}
 #endif //LINEARDICTIONARYGETTERS_TPP

--- a/src/LinearDictionary/LinearDictionarySetters.tpp
+++ b/src/LinearDictionary/LinearDictionarySetters.tpp
@@ -1,6 +1,9 @@
 #ifndef LINEARDICTIONARYSETTERS_TPP
 #define LINEARDICTIONARYSETTERS_TPP
 
+namespace dtr
+{
+
 template <typename TKey, typename TValue>
 void LinearDictionary<TKey, TValue>::Add(const TKey& key, const TValue& value) {
     if (ContainsKey(key)) throw std::invalid_argument("Key already exists");
@@ -18,4 +21,5 @@ void LinearDictionary<TKey, TValue>::InsertOrAssign(const TKey& key, const TValu
     _dict.emplace_back(key, value);
 }
 
+}
 #endif // LINEARDICTIONARYSETTERS_TPP

--- a/src/PerfectHashDictionary/PerfectHashDictionaryBuild.tpp
+++ b/src/PerfectHashDictionary/PerfectHashDictionaryBuild.tpp
@@ -3,6 +3,8 @@
 
 #define PERFHASH_MAX_ATTEMPTS 100
 
+namespace  dtr
+{
 
 template <CHashable TKey, typename TValue>
 template<CPairIterator<TKey, TValue> TIter>
@@ -132,6 +134,6 @@ template<CHashable TKey, typename TValue>
     }
 }
 
-
+}
 
 #endif // PERFECTDICTIONARY_TPP

--- a/src/PerfectHashDictionary/PerfectHashDictionaryGetters.tpp
+++ b/src/PerfectHashDictionary/PerfectHashDictionaryGetters.tpp
@@ -1,13 +1,16 @@
 #ifndef PERFECTDICTIONARYGETTERS_TPP
 #define PERFECTDICTIONARYGETTERS_TPP
 
+namespace dtr
+{
+
 template <CHashable TKey, typename TValue>
 uint64_t PerfectHashDictionary<TKey, TValue>::_findIndex(const TKey &key) const {
     auto stdHash = std::hash<TKey>{}(key);
     const auto& bucket = _buckets[_hashRaw(stdHash, _globalSeed, _tableSize)];
 
     if (bucket.Size == 0) return -1;
-    __builtin_prefetch(&_values[bucket.Offset], 0, 1);
+    PH_PREFETCH(&_values[bucket.Offset]);
     return bucket.Offset + _hashRaw(stdHash, bucket.Seed, bucket.Size);
 }
 
@@ -76,4 +79,5 @@ bool PerfectHashDictionary<TKey, TValue>::TryGetValidatedValue(const TKey& key, 
     return true;
 }
 
+}
 #endif // PERFECTDICTIONARYGETTERS_TPP

--- a/src/PerfectHashDictionary/PerfectHashDictionarySetters.tpp
+++ b/src/PerfectHashDictionary/PerfectHashDictionarySetters.tpp
@@ -1,6 +1,8 @@
 #ifndef PERFECTDICTIONARYSETTERS_TPP
 #define PERFECTDICTIONARYSETTERS_TPP
 
+namespace  dtr
+{
 
 template <CHashable TKey, typename TValue>
 void PerfectHashDictionary<TKey, TValue>::Add(const TKey& key, const TValue& value) {
@@ -64,5 +66,5 @@ void PerfectHashDictionary<TKey, TValue>::Clear() {
     _tableSize = 0;
 }
 
-
+}
 #endif // PERFECTDICTIONARYSETTERS_TPP

--- a/tests/PerfTest.cpp
+++ b/tests/PerfTest.cpp
@@ -3,8 +3,8 @@
 #include "Dictorium/Dictorium.h"
 #include "Utils/TestUtils.h"
 
-#define DICT_PERF_KEY_TYPE int
-#define DICT_PERF_KEYS 1'000
+#define DICT_PERF_KEY_TYPE std::string
+#define DICT_PERF_KEYS 1'000'000
 #define DICT_PERF_KEY_LEN 10
 #define DICT_PERF_TEST_INIT true
 
@@ -38,7 +38,7 @@ int main() {
 
     IDictionary<DICT_PERF_KEY_TYPE, double>& dictRef = dict;
     const auto dictFunc = [&](const DICT_PERF_KEY_TYPE& key) {
-        return dictRef.GetValue(key);
+        return dict.GetValue(key);
     };
 
     const auto phTime1 = Benchmark(data, dictFunc);

--- a/tests/Utils/TestUtils.cpp
+++ b/tests/Utils/TestUtils.cpp
@@ -33,7 +33,7 @@ DataStr GenerateDataStr(const size_t count, const size_t length) {
 
 
 DateTime GetNow() {
-    return std::chrono::high_resolution_clock::now();
+    return std::chrono::steady_clock::now();
 }
 
 size_t DurationNs(const DateTime start, const DateTime end) {

--- a/tests/Utils/TestUtils.h
+++ b/tests/Utils/TestUtils.h
@@ -1,6 +1,7 @@
 #ifndef TESTUTILS_H
 #define TESTUTILS_H
 
+#include <stdexcept>
 #include <random>
 #include <string>
 #include <chrono>

--- a/tests/Utils/TestUtils.h
+++ b/tests/Utils/TestUtils.h
@@ -6,7 +6,7 @@
 #include <chrono>
 
 using DataStr = std::vector<std::pair<std::string, double>>;
-using DateTime = std::chrono::time_point<std::chrono::system_clock>;
+using DateTime = std::chrono::time_point<std::chrono::steady_clock>;
 
 std::string GenerateStr(std::mt19937& rng, size_t length);
 DataStr GenerateDataStr(size_t count, size_t length);
@@ -20,8 +20,8 @@ std::vector<std::pair<TKey, double>> GenerateDataNum(const size_t count) {
     result.reserve(count);
 
     if constexpr (std::is_integral_v<TKey>) {
-        const __uint128_t range = static_cast<__uint128_t>(limits::max()) - static_cast<__uint128_t>(limits::lowest()) + 1;
-        if (static_cast<__uint128_t>(count) > range) throw std::invalid_argument("Too many unique keys for this integer type");
+        const size_t range = static_cast<size_t>(limits::max()) - static_cast<size_t>(limits::lowest()) + 1;
+        if (static_cast<size_t>(count) > range) throw std::invalid_argument("Too many unique keys for this integer type");
 
         std::vector<TKey> values(count);
         TKey start = std::numeric_limits<TKey>::lowest();

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -13,7 +13,7 @@ int main() {
 
   dict.Add("qwe", 123);
   std::cout << dict << std::endl;
-  print(dict.ContainsKey("qwe"));
+  std::cout << dict.ContainsKey("qwe");
 
   std::cout << dict["test1"] << '\n';
   std::cout << dict.Count() << '\n';


### PR DESCRIPTION
# Портируемость на `msvc`
- Исправлены места в коде, которые не давали собрать `Dictorium` под `msvc`.
- Измененные места:
    - Используется  `_umul128` вместо `__uint128_t` в случае использования `msvc`
    - Используется `std::chrono::steady_clock` вместо `std::chrono::high_resolution_clock` 
    - Добавлен `#include <stdexcept>`